### PR TITLE
Use disconnectedCallback to cancel render

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -1,18 +1,14 @@
-import {store, writer, mount, renderable, forward} from '../store-element.js'
+import {store, shadowWriter, mount, renderable, forward} from '../store-element.js'
 import {el, select} from '../dom.js'
 
-const button = writer({
+const button = shadowWriter({
+  style: `
+    .button {
+      font-size: 24px;
+    }
+  `,
   setup: (host, curr, handle) => {
     el(host)
-      .append(
-        el.create('style')
-          .html(`
-            .button {
-              font-size: 24px;
-            }
-          `)
-          .done()
-      )
       .append(
         el.create('button')
           .classes(['button'])
@@ -29,23 +25,19 @@ const button = writer({
 
 customElements.define('my-button', renderable(button))
 
-const main = writer({
+const main = shadowWriter({
+  style: `
+    .main {
+      background: blue;
+      width: 100vw;
+      height: 100vw;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  `,
   setup: (host, curr, handle) => {
     el(host)
-      .append(
-        el.create('style')
-          .html(`
-            .main {
-              background: blue;
-              width: 100vw;
-              height: 100vw;
-              display: flex;
-              align-items: center;
-              justify-content: center;
-            }
-          `)
-          .done()
-      )
       .append(
         el.create('my-button')
           .id('button')

--- a/example/example.js
+++ b/example/example.js
@@ -1,12 +1,7 @@
-import {store, shadowWriter, mount, renderable, forward} from '../store-element.js'
+import {store, view, component, writer, forward} from '../store-element.js'
 import {el, select} from '../dom.js'
 
-const button = shadowWriter({
-  style: `
-    .button {
-      font-size: 24px;
-    }
-  `,
+const writeButton = writer({
   setup: (host, curr, handle) => {
     el(host)
       .append(
@@ -23,19 +18,20 @@ const button = shadowWriter({
   }
 })
 
-customElements.define('my-button', renderable(button))
-
-const main = shadowWriter({
+const button = view({
   style: `
-    .main {
-      background: blue;
-      width: 100vw;
-      height: 100vw;
-      display: flex;
-      align-items: center;
-      justify-content: center;
+    .button {
+      font-size: 24px;
     }
   `,
+  write: writeButton
+})
+
+customElements.define('my-button', button)
+
+const click = () => ({type: 'click'})
+
+const writeMain = writer({
   setup: (host, curr, handle) => {
     el(host)
       .append(
@@ -52,26 +48,28 @@ const main = shadowWriter({
   }
 })
 
-customElements.define('my-main', renderable(main))
+const main = component({
+  init: ({clicks=0}) => ({clicks}),
+  update: (state, msg) => {
+    if (msg.type === 'click') {
+      return [
+        {...state, clicks: state.clicks + 1},
+        null
+      ]
+    }
+    return [state, null]
+  },
+  style: `
+    .main {
+      background: blue;
+      width: 100vw;
+      height: 100vw;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  `,
+  write: writeMain
+})
 
-const click = () => ({type: 'click'})
-
-const init = () => ({clicks: 0})
-
-const update = (state, msg) => {
-  if (msg.type === 'click') {
-    return [
-      {...state, clicks: state.clicks + 1},
-      null
-    ]
-  }
-  return [state, null]
-}
-
-const app = store({init, update})
-
-mount(
-  select('body'),
-  el.create('my-main').done(),
-  app
-)
+customElements.define('my-main', main)

--- a/example/index.html
+++ b/example/index.html
@@ -6,5 +6,6 @@
   <script type="module" src="example.js"></script>
 </head>
 <body>
+  <my-main state='{"clicks": 1}'></my-main>
 </body>
 </html>


### PR DESCRIPTION
Previously it was possible for an element to be removed while a render was still pending for it. This would result in unnecessary work being done.

This refined approach moves render logic into RenderableElement and takes advantage of disconnectedCallback to cancel any pending renders when element is removed from DOM.